### PR TITLE
Upgrade to node-github v9

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,18 +62,20 @@ module.exports = (robot, options, visit) => {
   }
 
   async function eachInstallation(callback) {
+    robot.log.trace('Fetching installations');
     const github = await robot.auth();
 
-    await github.paginate(github.integrations.getInstallations({}), installations => {
-      installations.forEach(callback);
+    await github.paginate(github.integrations.getInstallations({}), res => {
+      res.data.forEach(callback);
     });
   }
 
   async function eachRepository(installation, callback) {
+    robot.log.trace(installation, 'Fetching repositories for installation');
     const github = await robot.auth(installation.id);
 
-    return await github.paginate(github.integrations.getInstallationRepositories({}), data => {
-      data.repositories.forEach(async repository => await callback(repository, github));
+    return await github.paginate(github.integrations.getInstallationRepositories({}), res => {
+      res.data.repositories.forEach(async repository => await callback(repository, github));
     });
   }
 


### PR DESCRIPTION
https://github.com/probot/probot/pull/151 updates the GitHub client in probot, which has a [breaking change in v9](https://github.com/mikedeboer/node-github/blob/master/CHANGELOG.md#900):

> Always return a response as an object with data and meta attributes.

This is a work in progress to get everything working with the latest client.

cc @jbjonesjr