### PR TITLE
Bottleneck schedule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const Bottleneck = require('bottleneck');
 
-const limiter = new Bottleneck(1, 1000);
+const limiter = new Bottleneck(1, 0);
 
 const defaults = {
   delay: !process.env.DISABLE_DELAY, // Should the first run be put on a random delay?

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = (robot, options) => {
 
   function setup() {
     eachInstallation(installation => {
-      limiter.submit(eachRepository, installation, repository => {
+      limiter.schedule(eachRepository, installation, repository => {
         schedule(installation, repository);
       });
     });


### PR DESCRIPTION
256d893 is the fix for https://github.com/probot/stale/issues/51

The underlying cause is that Bottleneck's `submit` method relies on the last argument getting called once the block is done.  The current code is using the block as an iterator for each repository. So if an installation had zero repositories, then the block would never get called and it wouldn't move on to the next installation.  This is well documented in https://github.com/SGrondin/bottleneck#gotchas 
