### PR TITLE
Ignored accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Probot: Scheduler
 
-A [Probot](https://github.com/probot/probot) extension to trigger events on a periodic schedule.
+A [Probot](https://github.com/probot/probot) extension to trigger events on an hourly schedule.
 
 ## Usage
 
@@ -15,3 +15,11 @@ module.exports = robot => {
   });
 };
 ```
+
+## Configuration
+
+There are a few environment variables that can change the behavior of the scheduler:
+
+- `DISABLE_DELAY=true` - Perform the schedule immediately on startup, instead of waiting for the random delay between 0 and 59:59 for each repository, which exists to avoid all schedules being performed at the same time.
+
+- `IGNORED_ACCOUNTS=comma,separated,list` - GitHub usernames to ignore when scheduling. These are typically spammy or abusive accounts.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const Bottleneck = require('bottleneck')
 
 const limiter = new Bottleneck({ maxConcurrent: 1, minTime: 0 })
+const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '').split(',')
 
 const defaults = {
   delay: !process.env.DISABLE_DELAY, // Should the first run be put on a random delay?
@@ -32,6 +33,11 @@ module.exports = (robot, options) => {
   }
 
   function setupInstallation (installation) {
+    if (ignoredAccounts.includes(installation.account.login)) {
+      robot.log.debug({installation}, 'Installation is ignored')
+      return
+    }
+
     limiter.schedule(eachRepository, installation, repository => {
       schedule(installation, repository)
     })

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const Bottleneck = require('bottleneck')
 
 const limiter = new Bottleneck({ maxConcurrent: 1, minTime: 0 })
-const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '').split(',')
+const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '').toLowerCase().split(',')
 
 const defaults = {
   delay: !process.env.DISABLE_DELAY, // Should the first run be put on a random delay?
@@ -33,7 +33,7 @@ module.exports = (robot, options) => {
   }
 
   function setupInstallation (installation) {
-    if (ignoredAccounts.includes(installation.account.login)) {
+    if (ignoredAccounts.includes(installation.account.login.toLowerCase())) {
       robot.log.debug({installation}, 'Installation is ignored')
       return
     }


### PR DESCRIPTION
This PR does a small refactoring to remove some duplication (09f582e) and then adds an `IGNORED_ACCOUNTS` environment variable that is a comma separated list of GitHub usernames to ignore.

This is necessary because there are currently a few very abusive accounts (spammy, DMCA takedowns) that have installed several probot apps on hundreds or thousands of repositories, which is causing some pain.