### PR TITLE
Update standard to v12

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (robot, options) => {
 
   function setupInstallation (installation) {
     if (ignoredAccounts.includes(installation.account.login.toLowerCase())) {
-      robot.log.debug({installation}, 'Installation is ignored')
+      robot.log.debug({ installation }, 'Installation is ignored')
       return
     }
 
@@ -51,12 +51,12 @@ module.exports = (robot, options) => {
     // Wait a random delay to more evenly distribute requests
     const delay = options.delay ? options.interval * Math.random() : 0
 
-    robot.log.debug({repository, delay, interval: options.interval}, `Scheduling interval`)
+    robot.log.debug({ repository, delay, interval: options.interval }, `Scheduling interval`)
 
     intervals[repository.id] = setTimeout(() => {
       const event = {
         name: 'schedule',
-        payload: {action: 'repository', installation, repository}
+        payload: { action: 'repository', installation, repository }
       }
 
       // Trigger events on this repository on an interval
@@ -71,30 +71,30 @@ module.exports = (robot, options) => {
     robot.log.trace('Fetching installations')
     const github = await robot.auth()
 
-    const req = github.apps.getInstallations({per_page: 100})
+    const req = github.apps.getInstallations({ per_page: 100 })
     await github.paginate(req, res => {
       (options.filter ? res.data.filter(inst => options.filter(inst)) : res.data)
-        .forEach(callback);
+        .forEach(callback)
     })
   }
 
   async function eachRepository (installation, callback) {
-    robot.log.trace({installation}, 'Fetching repositories for installation')
+    robot.log.trace({ installation }, 'Fetching repositories for installation')
     const github = await robot.auth(installation.id)
 
-    const req = github.apps.getInstallationRepositories({per_page: 100})
+    const req = github.apps.getInstallationRepositories({ per_page: 100 })
     return github.paginate(req, res => {
       const repos = res.data.repositories;
       (options.filter ? repos.filter(repo => options.filter(installation, repo)) : repos)
-        .forEach(async repository => callback(repository, github));
+        .forEach(async repository => callback(repository, github))
     })
   }
 
   function stop (repository) {
-    robot.log.debug({repository}, `Canceling interval`)
+    robot.log.debug({ repository }, `Canceling interval`)
 
     clearInterval(intervals[repository.id])
   }
 
-  return {stop}
+  return { stop }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "bottleneck": "^2.0.1"
   },
   "devDependencies": {
-    "standard": "^10.0.3"
+    "standard": "^12.0.1"
   }
 }


### PR DESCRIPTION
This PR updates standard to [v12](https://standardjs.com/changelog.html#1200---2018-08-28). I ran `npx standard --fix` after installing to fix any violations.