### PR TITLE
Scheduler enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ There are a few runtime options you can pass that can change the behavior of the
 
 * `interval` - the number of milliseconds to schedule each repository. Default: 1 hour (`60 * 60 * 1000`)
 
+* `runOnce` - when `true`, the schedule will only be performed once. Default: `false`
+
 For example, if you want your app to be triggered *once every day* with *delay enabled on first run*:
 
 ```js
@@ -51,6 +53,23 @@ module.exports = (robot) => {
   
   robot.on('schedule.repository', context => {
     // this event is triggered once every day, with a random delay
+  })
+}
+```
+
+Run the schedule once immediately on startup.
+
+```js
+const createScheduler = require('probot-scheduler')
+
+module.exports = (robot) => {
+  createScheduler(robot, {
+    delay: false, // run immediately on startup
+    runOnce: true, // run only once
+  })
+  
+  robot.on('schedule.repository', context => {
+    // this event is triggered once and only once on startup
   })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ There are a few runtime options you can pass that can change the behavior of the
 
 * `interval` - the number of milliseconds to schedule each repository. Default: 1 hour (`60 * 60 * 1000`)
 
+* `repos` - an array of full repository names that the schedule is performed for. Default: `[]`
+
 For example, if you want your app to be triggered *once every day* with *delay enabled on first run*:
 
 ```js
@@ -51,6 +53,25 @@ module.exports = (robot) => {
   
   robot.on('schedule.repository', context => {
     // this event is triggered once every day, with a random delay
+  })
+}
+```
+
+Run the schedule only for a particular repo.
+
+```js
+const createScheduler = require('probot-scheduler')
+
+module.exports = (robot) => {
+  createScheduler(robot, {
+    delay: !!process.env.DISABLE_DELAY, // delay is enabled on first run
+    interval: 24 * 60 * 60 * 1000, // 1 day
+    repos: [ 'octocat/Hello-World' ]
+  })
+  
+  robot.on('schedule.repository', context => {
+    // this event is triggered once every day, with a random delay, but
+    // only for the specified repository
   })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ There are a few runtime options you can pass that can change the behavior of the
 
 * `interval` - the number of milliseconds to schedule each repository. Default: 1 hour (`60 * 60 * 1000`)
 
+* `name` - the name of the action to be triggered by the scheduler instance. Default: `repository`
+
 For example, if you want your app to be triggered *once every day* with *delay enabled on first run*:
 
 ```js
@@ -51,6 +53,34 @@ module.exports = (robot) => {
   
   robot.on('schedule.repository', context => {
     // this event is triggered once every day, with a random delay
+  })
+}
+```
+
+Add a second hourly schedule.
+
+```js
+const createScheduler = require('probot-scheduler')
+
+module.exports = (robot) => {
+  createScheduler(robot, {
+    name: 'daily',
+    delay: !!process.env.DISABLE_DELAY, // delay is enabled on first run
+    interval: 24 * 60 * 60 * 1000 // 1 day
+  })
+
+  createScheduler(robot, {
+    name: 'hourly',
+    delay: !!process.env.DISABLE_DELAY, // delay is enabled on first run
+    interval: 60 * 60 * 1000 // 1 hour
+  })
+
+  robot.on('schedule.daily', context => {
+    // this event is triggered once every day, with a random delay
+  })
+
+  robot.on('schedule.hourly', context => {
+    // this event is triggered once every hour, with a random delay
   })
 }
 ```

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '')
   .split(',')
 
 const defaults = {
+  name: 'schedule',
   delay: !process.env.DISABLE_DELAY, // Should the first run be put on a random delay?
   interval: 60 * 60 * 1000 // 1 hour
 }
@@ -58,7 +59,7 @@ module.exports = (app, options) => {
     intervals[repository.id] = setTimeout(() => {
       const event = {
         name: 'schedule',
-        payload: { action: 'repository', installation, repository }
+        payload: { action: options.name, installation, repository }
       }
 
       // Trigger events on this repository on an interval

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '')
 
 const defaults = {
   delay: !process.env.DISABLE_DELAY, // Should the first run be put on a random delay?
-  interval: 60 * 60 * 1000 // 1 hour
+  interval: 60 * 60 * 1000, // 1 hour
+  runOnce: false
 }
 
 module.exports = (app, options) => {
@@ -61,11 +62,13 @@ module.exports = (app, options) => {
         payload: { action: 'repository', installation, repository }
       }
 
-      // Trigger events on this repository on an interval
-      intervals[repository.id] = setInterval(
-        () => app.receive(event),
-        options.interval
-      )
+      if (!options.runOnce) {
+        // Trigger events on this repository on an interval
+        intervals[repository.id] = setInterval(
+          () => app.receive(event),
+          options.interval
+        )
+      }
 
       // Trigger the first event now
       app.receive(event)


### PR DESCRIPTION
1. Multiple schedules, #18
2. Run schedule only once
3. Run schedule only for specified repositories

-----
[View rendered README.md](https://github.com/JEStaubach/scheduler/blob/feature-schedulerEnhancements/README.md)